### PR TITLE
fix: get current list of browser ids from test collection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,8 @@ const parseConfig = require('./config');
 
 const isMatched = (matcher, value) => _.isRegExp(matcher) ? matcher.test(value) : _.isEqual(matcher, value);
 const shouldRunInBro = (browserId, matcher) => [].concat(matcher).some((m) => isMatched(m, browserId));
-const getPassiveBrowserIds = (hermione, {browsers: passiveBrowserMatchers}) => {
-    const browserIds = hermione.config.getBrowserIds();
+const getPassiveBrowserIds = (testCollection, {browsers: passiveBrowserMatchers}) => {
+    const browserIds = testCollection.getBrowsers();
 
     return _([].concat(passiveBrowserMatchers))
         .flatMap((browserMatcher) => browserIds.filter((browserId) => isMatched(browserMatcher, browserId)))
@@ -51,7 +51,7 @@ module.exports = (hermione, opts) => {
     });
 
     hermione.prependListener(hermione.events.AFTER_TESTS_READ, (testCollection) => {
-        const passiveBrowserIds = getPassiveBrowserIds(hermione, config);
+        const passiveBrowserIds = getPassiveBrowserIds(testCollection, config);
 
         passiveBrowserIds.forEach((browserId) => {
             const shouldRunTest = (runnable, storage = testsToRun) => {


### PR DESCRIPTION
**Problem**:
- when run tests with specified browser -> `./node-modules/.bin/hermione some-test.js -b chrome-desktop` there is no information about other browsers in tree collection. And calling the method `testCollection.eachTest('non-existent-bro', () => {...})` throws the error.

**Solution**:
- get browser ids from test collection, not from hermione config in which the list of browsers does not depend on the launch of the command `npx hermione some-test.js -b chrome-desktop`
